### PR TITLE
yaml lint: ignoring the whole `.github` folder

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 # For all rules
 ignore: |
-  .github/workflows/lint.yml
+  .github
 
 rules:
   # We are not limiting line length, because non-programmer translators might not be aware of it.


### PR DESCRIPTION
Made yaml lint ignore `.github` folder completely