### PR TITLE
Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
Force modern editors to encode files "the right way"™, and also to use the same line ending