### PR TITLE
Option 2: Alternative version of a en-US version of home using keys and Markdown

### DIFF
--- a/Localization/en-US/home.yaml
+++ b/Localization/en-US/home.yaml
@@ -1,76 +1,50 @@
 ---
 url: "https://foldingathome.org/"
-title: "Folding@home"
 language: "en-US"
-text: [
-# I AM One IN A MILLION bold text
-"I AM One IN A MILLION",
+text:
+  # Header
+  header_headline: "I AM **One** IN A MILLION"
+  header_text: "Regardless if you are already folding or haven't heard a word about it before, we need your help to reach our goal -- which is 1 million folders."
+  header_button: "START FOLDING NOW"
+  header_hide_and_watch: "Hide this and watch the video."
 
-# Associated text
-"Regardless if you are already folding or haven't heard a word about it before, we need your help to reach our goal -- which is 1 million folders.",
-
-#Associated square button
-"START FOLDING NOW",
-
-#Associated text with the aobve square button
-"Hide this and watch the video.",
-
-# START FOLDING NOW bold text
-"START FOLDING NOW",
-
-# Associated text
+  # Start Folding Box
+  start_headline: "START FOLDING NOW"
+  start_text: \
 "Find the version of the software you prefer and get started. Downloading Folding@home is completely free, easy to install and safe to use.
 Available for:
 Linux
 Windows
-Mac",
+Mac"
+  start_button: "START FOLDING"
 
-#Associated square button
-"START FOLDING",
-
-#JOIN THE COMMUNITY bold text
-"JOIN THE COMMUNITY",
-
-# Associated text
+  # Join The Community Box
+  join_headline: "JOIN THE COMMUNITY"
+  join_text: \
 "The Folding@Home community is spread over countless forums, websites and social media.
 Here's a list of our official channels.
-For tech support: ",
+For tech support:
+[foldingforum.org](https://foldingforum.org)
+[Facebook](https://www.facebook.com/Foldinghome-136059519794607/)
+[Twitter](https://twitter.com/foldingathome)"
 
-#URLs - Facebook and Twitter have localised name in certain languages:
-"foldingforum.org",
-"Facebook",
-"Twitter",
+  # Latest Posts Box
+  latest_headline: "LATEST POSTS"
 
-#LATEST POSTS bold text
-"LATEST POSTS",
+  # Why We Need You Box
+  why_headline: "WHY WE NEED YOU"
+  why_text: "Folding@home is a project focused on disease research. The problems we're solving require so many computer calculations and we need your help to find the cures!"
 
-# WHY WE NEED YOU bold text
-"WHY WE NEED YOU",
+  # Fight Diseases With Us Box
+  fight_headline: "FIGHT DISEASES TOGETHER WITH US."
+  fight_text: "The Folding@home software allows you to share your unused computer power with us so that we can research even more potential cures."
+  fight_tag_text: "1 in a million"
 
-# Associated text
-"Folding@home is a project focused on disease research. The problems we're solving require so many computer calculations and we need your help to find the cures!",
+  # Folding Section
+  folding_headline: "FOLDING?"
+  folding_text: "Folding refers to the way human protein folds in the cells that make up your body. We rely on the proteins to keep us healthy and they assemble themselves by folding. But when they misfold, there can be serious consequences to a person's health."
+  folding_button: "LEARN MORE"
 
-#FIGHT DESIEASES TOGETHER WITH US bold text
-"FIGHT DISEASES TOGETHER WITH US.",
-
-#Associated text
-"The Folding@home software allows you to share your unused computer power with us so that we can research even more potential cures.",
-
-#Associated text in pentagon
-"1 in a million",
-
-#FOLDING? bold text
-"FOLDING?",
-
-#Associated text
-"Folding refers to the way human protein folds in the cells that make up your body. We rely on the proteins to keep us healthy and they assemble themselves by folding. But when they misfold, there can be serious consequences to a person's health.",
-
-#Associated square button
-"LEARN MORE",
-
-#TEAM bold text
-"TEAM",
-
-#Associated text
-"Folding@home is now based at the Washington University in St. Louis School of Medicine, under the directorship of  Dr. Greg Bowman. Drs. John Chodera (MSKCC) and Vince Voelz (Temple University) are also active in helping manage the project. Together, their three labs are the primary drivers of Folding@home."
-]
+  # Team Section
+  team_headline: "TEAM"
+  team_text: "Folding@home is now based at the Washington University in St. Louis School of Medicine, under the directorship of  Dr. Greg Bowman. Drs. John Chodera (MSKCC) and Vince Voelz (Temple University) are also active in helping manage the project. Together, their three labs are the primary drivers of Folding@home."


### PR DESCRIPTION
This idea (as an alternative to #47) tries to reduce the number of individual text blocks in the translation files to keep them as consistent as possible with the actual layout of the page. (Following a suggestion from @max-dau.)

### Benefits
* Clearly identifiable keys for every text block (similar to #47)
* More consistency between the YAML file layout and the page layout

### Disadvantages
* Markdown in the text blocks allows translators more control over layout than they maybe should have
* Links targets are part of the translation files, not of the layout (and changing them requires updates to all translation files)