### PR TITLE
validation: printing on stdout so messages don't overlap

### DIFF
--- a/validate_yaml.py
+++ b/validate_yaml.py
@@ -4,6 +4,7 @@ import fnmatch
 import yaml
 import traceback
 import os
+import sys
 
 
 def find(pattern, path):
@@ -53,6 +54,6 @@ for path in find("*.yaml", "Localization"):
             ensure_language(translation, path)
         except Exception as e:
             exit_code = 1
-            traceback.print_exc()
+            traceback.print_exc(file=sys.stdout)
 
 exit(exit_code)


### PR DESCRIPTION
The previous version was printing on both stdout and stderr, causing messages and exception tracebacks to overlap (when running the validation script on GitHub actions). This change forces both messages to print on stdout, so messages don't overlap any more