### PR TITLE
Add very basic validation of .po files

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,6 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: Tar-Minyatur/gettext-validation@master
+      - uses: Tar-Minyatur/gettext-validation@v1.0
         with:
           folder: Localization/

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Tar-Minyatur/gettext-validation@master
         with:
-          folder: translations/
+          folder: Localization/

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,11 @@
+---
+name: Validate translation files
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Tar-Minyatur/gettext-validation@master
+        with:
+          folder: translations/


### PR DESCRIPTION
This adds a very simple GitHub Workflow that will run gettext's `msgfmt` on all .po files in the repository to check if they are valid.