### PR TITLE
ja-JP : add translated pages (covid-19, faq, statistics)

### DIFF
--- a/Localization/ja-JP/covid-19.po
+++ b/Localization/ja-JP/covid-19.po
@@ -1,0 +1,89 @@
+msgid ""
+msgstr ""
+"FAH-Translate-Schema-Version: 1.0\n"
+"URL: https://foldingathome.org/covid-19/\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Source-Language: en-US\n"
+"Source-Version: 1.1\n"
+"Source-Last-Modified: 20200715\n"
+"Target-Language: ja-JP\n"
+"Target-Version: 1.1.0\n"
+"Target-Last-Modified: 20200725\n"
+
+msgid "COVID-19"
+msgstr "COVID-19"
+
+msgid "Coronavirus – What we’re doing and how you can help"
+msgstr "新型コロナウイルス－私たちが行っていること、あなたが手助けできること"
+
+msgid "Proteins are molecular machines that perform many functions we associate with life. They sense the environment (e.g. in taste and smell), perform work (e.g. muscle contraction and breaking down food), and play structural roles (e.g. your hair). They are made of a linear chain of chemicals called amino acids that, in many cases, spontaneously “fold” into compact, functional structures. Much like any other machine, it’s how a protein’s components are arranged and move that determine the protein’s function. In this case, the components are atoms."
+msgstr "タンパク質は、生命に関わるたくさんの働きをする分子機械です。彼らは環境（例：味や匂い）を感じ取り、仕事（例：筋肉の収縮や食物の分解）を行い、構造としての役割（例：髪の毛）も果たします。タンパク質はアミノ酸と呼ばれる化学物質の鎖からできており、多くの場合、自然と小さくて機能的な構造に“折りたたまれ”ます。他の機械と同様に、タンパク質の機能を決めるのは、タンパク質の部品がどのように配置され、動くかです。タンパク質の場合、部品とは原子のことです。"
+
+msgid "Viruses also have proteins that they use to suppress our immune systems and reproduce themselves."
+msgstr "ウイルスも同じく、私たちの免疫系を抑制し、自らを複製するためにタンパク質を持っています。"
+
+msgid "To help tackle coronavirus, we want to understand how these viral proteins work and how we can design therapeutics to stop them."
+msgstr "新型コロナウイルスへの取り組みを支援するために、私たちはこれらのウイルスタンパク質がどのように働き、ウイルスを止めるための治療法をどのように設計できるか理解したいのです。"
+
+msgid "There are many experimental methods for determining protein structures. While extremely powerful, they only reveal a single snapshot of a protein’s usual shape. But proteins have lots of moving parts, so we really want to see the protein in action. The structures we can’t see experimentally may be the key to discovering a new therapeutic."
+msgstr "タンパク質の構造を決める実験的な方法はたくさんあります。それらは非常に強力ですが、タンパク質が通常とる形状の一瞬の姿しか明らかにできません。タンパク質には多くの可動部があり、本当は動いている姿が見たいのです。実験的には確認できない構造が、新たな治療法を発見する鍵になるかもしれません。"
+
+msgid "Using football as an analogy for the experimental situation, it’s as if you could only see the players lined up for the snap (the single arrangement the players spend the most time in) and were blind to the rest of the game."
+msgstr "実験の状態をフットボールに例えると、スナップ（選手がほとんどの時間を費やす配置）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
+
+msgid "Seeing a single structure of a protein (left) is like seeing players lined up for the snap in football. Important information, but a lot missing too. The protein structure shows a sphere for each atom (blue) and red arrows highlighting the one drug binding site in this protein."
+msgstr "タンパク質の単一の構造（左）を見ているのは、フットボールのスナップで並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"
+
+msgid "Our specialty is in using computer simulations to understand proteins’ moving parts. Watching how the atoms in a protein move relative to one another is important because it captures valuable information that is inaccessible by any other means."
+msgstr "私たちは、タンパク質の可動部を理解するためのコンピューターシミュレーションの専門家です。タンパク質の原子がお互いにどう動くかを見ることは、他の手段ではたどり着けない貴重な情報を得られるので重要です。"
+
+msgid "Taking the experimental structures as starting points, we can simulate how all the atoms in the protein move, effectively filling in the rest of the game that experiments miss."
+msgstr "実験で得られた構造を出発点に、私たちはタンパク質の全ての原子がどのように動くかをシミュレーションし、実験で見逃していた残りの情報を効果的に得られます。"
+
+msgid "A movie capturing how the protein shown before moves is like getting to watch the whole football game. In this case, we see a pocket form that was absent in the experimental structure."
+msgstr "上の動画ではタンパク質がどのように動くかが捉えられており、例えるならフットボールの試合全てを見られるのと同様です。この場合、実験的な構造にはなかったポケット状の部位を発見できました。"
+
+msgid "Doing so can reveal new therapeutic opportunities. For example, in our recent [paper](https://www.biorxiv.org/content/10.1101/2020.02.09.940510v1.abstract), we simulated a protein from Ebola virus that is typically considered ‘undruggable’ because the snapshots from experiments don’t have obvious druggable sites. But, our simulations uncovered an alternative structure that does have a druggable site. Importantly, we then performed experiments that confirmed our computational prediction, and are now searching for drugs that bind this newly discovered binding site."
+msgstr "こういったシミュレーションにより、新たな治療法の可能性を明らかにできます。例えば、私たちの最近の[論文](https://www.biorxiv.org/content/10.1101/2020.02.09.940510v1.abstract)では、実験で捉えた構造に明らかな薬の効く部位がないため一般的には“薬が効かない”とされている、エボラウイルス由来のタンパク質のシミュレーションを行いました。定説に反し、私たちのシミュレーションによって、薬の効く部位を持つ別の構造が明らかになりました。私たちはその後、計算上の予測を実験でも確認し、現在はこの新たに発見された結合部に結合できる薬を探しています。"
+
+msgid "An experimental structure of an Ebola protein doesn’t have obvious druggable sites (no deep pockets among the atoms shown as spheres).Our simulations captured a motion that creates a potentially druggable site in this Ebola protein. Instead of showing spheres for each atom, this cartoon shows a ribbon tracing the linear chain of amino acids (chemicals) the protein is made of."
+msgstr "エボラタンパク質の実験的な構造には、明らかな薬の効く部位がありませんでした（球で示されている原子の間に深いポケットがない）。私たちのシミュレーションでは、このエボラタンパク質に薬が効くかもしれない部位を作り出す動きを捉えました。各原子を球で示す変わりに、この図ではタンパク質を形成するアミノ酸（化学物質）の鎖をたどるリボンを示しています。"
+
+msgid "We want to do the same thing with coronavirus."
+msgstr "私たちは、新型コロナウイルスでも同じことを達成したいと考えています。"
+
+msgid "Spreading the knowledge, Opensource"
+msgstr "知識を広げる、オープンソース"
+
+msgid "When we are done with our analysis we upload the data here:"
+msgstr "分析が完了したら、私たちはこちらにデータをアップロードします："
+
+msgid "We also make all data publicly available, so that other people working in the field can check our analysis and anyone with new methods (e.g. the always growing machine learning data analysis) can look at them at any time: [https://osf.io/2h6p4/wiki/home/](https://osf.io/2h6p4/wiki/home/) and [https://osf.io/dp4cb/wiki/home/](https://osf.io/dp4cb/wiki/home/)"
+msgstr "また、全てのデータは一般公開され、いつでも分野の他の人々が私たちの分析結果を確認したり、新たな方法（例：刻々と発展している機械学習）を考えた人がそれらを閲覧したりできます：[https://osf.io/2h6p4/wiki/home/](https://osf.io/2h6p4/wiki/home/)、[https://osf.io/dp4cb/wiki/home/](https://osf.io/dp4cb/wiki/home/)"
+
+msgid "We are also collaborating with other labs and groups outside the Foldingathome Consortium to solve COVID-19 asap."
+msgstr "さらに、早急にCOVID-19を解決するため、私たちはFoldingathomeコンソーシアム外の他の研究室やグループとも協力しています。"
+
+msgid "What you can do"
+msgstr "あなたにできること"
+
+msgid "1. Donate computing power:"
+msgstr "計算力を寄付する："
+
+msgid "[Downloading Folding@home](/start-folding/) and helping us run simulations is the primary way to contribute. These calculations are enormous and every little bit helps! Each simulation you run is like buying a lottery ticket. The more tickets we buy, the better our chances of hitting the jackpot. Usually, your computer will never be idle, but we’ve had such an enthusiastic response to our COVID-19 work that you will see some intermittent downtime as we sprint to setup more simulations. Please be patient with us! There is a lot of valuable science to be done, and we’re getting it running as quickly as we can."
+msgstr "[Folding@homeをダウンロード](/start-folding/)し、シミュレーションの実行を支援することが主要な貢献の仕方です。これらの計算は膨大であり、少しの計算でも役に立ちます！　あなたが実行するそれぞれのシミュレーションは、宝くじを買うようなものです。買うくじが多ければ多いほど、当選する可能性は上がります。通常、あなたのコンピュータが計算を止めることは決してありませんが、COVID-19への取り組みに熱狂的な反応をいただいているため、私たちがさらなるシミュレーションを準備するまでに断続的な停止時間が発生することがあります。お待ちいただけますと幸いです。実施しなければならない貴重な研究は山ほどあり、できる限り速く実行に移しています。"
+
+msgid "To focus on Covid-19 research you can set the project category in your FAH client to “COVID-19”."
+msgstr "COVID-19の研究を集中的に行うには、FAHクライアントのプロジェクトカテゴリに“COVID-19”を指定してください。"
+
+msgid "2) If you don’t have computers to contribute or are feeling particularly generous, you can also [make donations](https://gifts.wustl.edu/med/index.html?other_designation_description=Folding@Home%20(Dr%20Greg%20Bowman,%20Dept%20of%20Biochemistry)&0_d_tr1=71&sc=NG) through Washington University in St. Louis. These funds are used for a number of purposes, including:"
+msgstr "2) 貢献できるコンピューターがない、または特に寛大である場合は、セントルイス・ワシントン大学を通じて[ご寄付をいただく](https://gifts.wustl.edu/med/index.html?other_designation_description=Folding@Home%20(Dr%20Greg%20Bowman,%20Dept%20of%20Biochemistry)&0_d_tr1=71&sc=NG)こともできます。この資金は次のような多くの目的に活用されます："
+
+msgid "2.1) Supporting our software engineering and server-side hardware (particularly important right now as we scale up rapidly!)"
+msgstr "2.1) ソフトウェアエンジニアリングとサーバー側のハードウェアの補強（現在Folding@homeは急速に拡大しているため、特に重要です！）"
+
+msgid "2.2) Buying compounds to test experimentally based on insight from our simulations."
+msgstr "2.2) シミュレーションで得られた知見に基づいて、実験的に検証するための化合物の購入"
+
+msgid "Covid-19 collaborators"
+msgstr "COVID-19プロジェクトの協力者"

--- a/Localization/ja-JP/covid-19.po
+++ b/Localization/ja-JP/covid-19.po
@@ -7,8 +7,8 @@ msgstr ""
 "Source-Version: 1.1\n"
 "Source-Last-Modified: 20200715\n"
 "Target-Language: ja-JP\n"
-"Target-Version: 1.1.0\n"
-"Target-Last-Modified: 20200725\n"
+"Target-Version: 1.1.1\n"
+"Target-Last-Modified: 20200728\n"
 
 msgid "COVID-19"
 msgstr "COVID-19"
@@ -29,10 +29,10 @@ msgid "There are many experimental methods for determining protein structures. W
 msgstr "タンパク質の構造を決める実験的な方法はたくさんあります。それらは非常に強力ですが、タンパク質が通常とる形状の一瞬の姿しか明らかにできません。タンパク質には多くの可動部があり、本当は動いている姿が見たいのです。実験的には確認できない構造が、新たな治療法を発見する鍵になるかもしれません。"
 
 msgid "Using football as an analogy for the experimental situation, it’s as if you could only see the players lined up for the snap (the single arrangement the players spend the most time in) and were blind to the rest of the game."
-msgstr "実験の状態をフットボールに例えると、スナップ（選手がほとんどの時間を費やす配置）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
+msgstr "実験の状態をアメリカンフットボールに例えると、スナップ（攻撃開始前、ボールを投げる瞬間）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
 
 msgid "Seeing a single structure of a protein (left) is like seeing players lined up for the snap in football. Important information, but a lot missing too. The protein structure shows a sphere for each atom (blue) and red arrows highlighting the one drug binding site in this protein."
-msgstr "タンパク質の単一の構造（左）を見ているのは、フットボールのスナップで並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"
+msgstr "タンパク質の単一の構造（左）を見ているのは、アメリカンフットボールのスナップで並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"
 
 msgid "Our specialty is in using computer simulations to understand proteins’ moving parts. Watching how the atoms in a protein move relative to one another is important because it captures valuable information that is inaccessible by any other means."
 msgstr "私たちは、タンパク質の可動部を理解するためのコンピューターシミュレーションの専門家です。タンパク質の原子がお互いにどう動くかを見ることは、他の手段ではたどり着けない貴重な情報を得られるので重要です。"
@@ -41,7 +41,7 @@ msgid "Taking the experimental structures as starting points, we can simulate ho
 msgstr "実験で得られた構造を出発点に、私たちはタンパク質の全ての原子がどのように動くかをシミュレーションし、実験で見逃していた残りの情報を効果的に得られます。"
 
 msgid "A movie capturing how the protein shown before moves is like getting to watch the whole football game. In this case, we see a pocket form that was absent in the experimental structure."
-msgstr "上の動画ではタンパク質がどのように動くかが捉えられており、例えるならフットボールの試合全てを見られるのと同様です。この場合、実験的な構造にはなかったポケット状の部位を発見できました。"
+msgstr "上の動画ではタンパク質がどのように動くかが捉えられており、例えるならアメリカンフットボールの試合全てを見られるのと同様です。この場合、実験的な構造にはなかったポケット状の部位を発見できました。"
 
 msgid "Doing so can reveal new therapeutic opportunities. For example, in our recent [paper](https://www.biorxiv.org/content/10.1101/2020.02.09.940510v1.abstract), we simulated a protein from Ebola virus that is typically considered ‘undruggable’ because the snapshots from experiments don’t have obvious druggable sites. But, our simulations uncovered an alternative structure that does have a druggable site. Importantly, we then performed experiments that confirmed our computational prediction, and are now searching for drugs that bind this newly discovered binding site."
 msgstr "こういったシミュレーションにより、新たな治療法の可能性を明らかにできます。例えば、私たちの最近の[論文](https://www.biorxiv.org/content/10.1101/2020.02.09.940510v1.abstract)では、実験で捉えた構造に明らかな薬の効く部位がないため一般的には“薬が効かない”とされている、エボラウイルス由来のタンパク質のシミュレーションを行いました。定説に反し、私たちのシミュレーションによって、薬の効く部位を持つ別の構造が明らかになりました。私たちはその後、計算上の予測を実験でも確認し、現在はこの新たに発見された結合部に結合できる薬を探しています。"

--- a/Localization/ja-JP/covid-19.po
+++ b/Localization/ja-JP/covid-19.po
@@ -29,7 +29,7 @@ msgid "There are many experimental methods for determining protein structures. W
 msgstr "タンパク質の構造を決める実験的な方法はたくさんあります。それらは非常に強力ですが、タンパク質が通常とる形状の一瞬の姿しか明らかにできません。タンパク質には多くの可動部があり、本当は動いている姿が見たいのです。実験的には確認できない構造が、新たな治療法を発見する鍵になるかもしれません。"
 
 msgid "Using football as an analogy for the experimental situation, it’s as if you could only see the players lined up for the snap (the single arrangement the players spend the most time in) and were blind to the rest of the game."
-msgstr "実験の状態をアメリカンフットボールに例えると、スナップ（攻撃開始前、ボールを投げる瞬間）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
+msgstr "実験でわかることをアメリカンフットボールに例えると、スナップ（攻撃開始前、ボールを投げる瞬間）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
 
 msgid "Seeing a single structure of a protein (left) is like seeing players lined up for the snap in football. Important information, but a lot missing too. The protein structure shows a sphere for each atom (blue) and red arrows highlighting the one drug binding site in this protein."
 msgstr "タンパク質の単一の構造（左）を見ているのは、アメリカンフットボールのスナップで並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"

--- a/Localization/ja-JP/covid-19.po
+++ b/Localization/ja-JP/covid-19.po
@@ -8,7 +8,7 @@ msgstr ""
 "Source-Last-Modified: 20200715\n"
 "Target-Language: ja-JP\n"
 "Target-Version: 1.1.1\n"
-"Target-Last-Modified: 20200728\n"
+"Target-Last-Modified: 20200731\n"
 
 msgid "COVID-19"
 msgstr "COVID-19"
@@ -29,10 +29,10 @@ msgid "There are many experimental methods for determining protein structures. W
 msgstr "タンパク質の構造を決める実験的な方法はたくさんあります。それらは非常に強力ですが、タンパク質が通常とる形状の一瞬の姿しか明らかにできません。タンパク質には多くの可動部があり、本当は動いている姿が見たいのです。実験的には確認できない構造が、新たな治療法を発見する鍵になるかもしれません。"
 
 msgid "Using football as an analogy for the experimental situation, it’s as if you could only see the players lined up for the snap (the single arrangement the players spend the most time in) and were blind to the rest of the game."
-msgstr "実験でわかることをアメリカンフットボールに例えると、スナップ（攻撃開始前、ボールを投げる瞬間）のために並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
+msgstr "実験でわかることをアメリカンフットボールに例えると、スナップ（攻撃開始前、ボールを投げる瞬間）に向けて一列に並んでいる選手しか見ることができず、試合の残りは見られないようなものです。"
 
 msgid "Seeing a single structure of a protein (left) is like seeing players lined up for the snap in football. Important information, but a lot missing too. The protein structure shows a sphere for each atom (blue) and red arrows highlighting the one drug binding site in this protein."
-msgstr "タンパク質の単一の構造（左）を見ているのは、アメリカンフットボールのスナップで並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"
+msgstr "タンパク質の単一の構造（左）を見ているのは、スナップに向けて並ぶ選手を見ているのと同じです。それも重要な情報ですが、不足も多いのです。タンパク質の構造図では、青い球がそれぞれの原子を、赤い矢印が薬と結合可能な部位を示しています。"
 
 msgid "Our specialty is in using computer simulations to understand proteins’ moving parts. Watching how the atoms in a protein move relative to one another is important because it captures valuable information that is inaccessible by any other means."
 msgstr "私たちは、タンパク質の可動部を理解するためのコンピューターシミュレーションの専門家です。タンパク質の原子がお互いにどう動くかを見ることは、他の手段ではたどり着けない貴重な情報を得られるので重要です。"

--- a/Localization/ja-JP/faq.po
+++ b/Localization/ja-JP/faq.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"FAH-Translate-Schema-Version: 1.0\n"
+"URL: https://foldingathome.org/support/faq/\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Source-Language: en-US\n"
+"Source-Version: 1.0\n"
+"Source-Last-Modified: 20200705\n"
+"Target-Language: ja-JP\n"
+"Target-Version: 1.0.0\n"
+"Target-Last-Modified: 20200725\n"
+
+msgid "FAQ"
+msgstr "よくある質問"
+
+msgid "You'll find a large library of frequently asked questions about all things connected to Folding@home."
+msgstr "Folding@homeに関するよくある質問を掲載しています。"
+
+msgid "This section contains everything from guides and information about how to install and use the Folding@home software to the science behind our research. Look through the sidebar and find the topic you want to know more about."
+msgstr "このセクションには、Folding@homeソフトウェアのインストールや使用方法のガイド・情報から、私たちの研究の背景にある科学に至るまで幅広い情報があります。サイドバーから、ご覧になりたいトピックをお選びください。"

--- a/Localization/ja-JP/statistics.po
+++ b/Localization/ja-JP/statistics.po
@@ -1,0 +1,47 @@
+msgid ""
+msgstr ""
+"FAH-Translate-Schema-Version: 1.0\n"
+"URL: https://foldingathome.org/statistics/\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Source-Language: en-US\n"
+"Source-Version: 1.0\n"
+"Source-Last-Modified: 20200705\n"
+"Target-Language: ja-JP\n"
+"Target-Version: 1.0.0\n"
+"Target-Last-Modified: 20200725\n"
+
+msgid "Statistics"
+msgstr "統計情報"
+
+msgid "One of the best ways to help Folding@home is by recruiting your friends and family. Start by sharing our project with them. Then join a team or even start your own team. The more points your team earns, the closer we come to finding cures."
+msgstr "Folding@homeを助ける一番良い方法の1つは、あなたの友達や家族にも勧めることです。まずは、私たちのプロジェクトを皆さんに知らせてください。そして、チームに参加するか、あなた自身のチームを作成してください。あなたのチームが多くのポイントを獲得すればするほど、私たちは治療法の発見に近づけます。"
+
+msgid "On this page you will find access to statistics for individuals and teams who have joined together to earn points and compete with other teams. Some of us are quite intense in our approach to folding. We have team websites, we supe up our computers, and we drive the technology forward by reporting bugs and making suggestions about how to improve the software."
+msgstr "このページでは、ポイントを獲得して他チームと競い合うために参加した個人やチームの統計情報にアクセスできます。一部の人々は非常に真剣にFolding@homeに取り組んでいます。チームのウェブサイトを持ったり、コンピューターを強化したり、バグ報告やソフトウェアの改善を提案して技術を進展させたりする人もいます。"
+
+msgid "**MAXIMIZE** your **EFFORT**"
+msgstr "あなたの**成果**を**最大化**しよう"
+
+msgid "Set up your team"
+msgstr "チームを作成しよう"
+
+msgid "If you are interested in setting up a team of your own, you can get started here."
+msgstr "あなた自身のチームを作ることにご興味がありましたら、こちらからどうぞ。"
+
+msgid "Start a team"
+msgstr "チームをはじめる"
+
+msgid "Lost team password?"
+msgstr "パスワードを忘れましたか？"
+
+msgid "Change your team info"
+msgstr "チームの情報を変更する"
+
+msgid "Monitoring stats updates automatically: available downloads and rules of use"
+msgstr "統計情報の更新を自動で監視する：ダウンロード可能なデータと使用のルール"
+
+msgid "The donor and team stats are updated every hour, although this can be delayed if there were a lot of work units to come back during that hour. We have been turning off web access to the stats database during stats updates (usually on the hour)."
+msgstr "貢献者とチームの統計は1時間ごとに更新されますが、その時間に多くの結果が提出された場合には遅れる場合があります。統計の更新中（通常は毎時0分）には、統計データベースへのウェブアクセスは遮断されます。"
+
+msgid "Please do not use scripts to access the donor or team pages, but use the full donor list (flat files) instead. IP addresses which do not abide by our robots.txt rules will be banned."
+msgstr "スクリプトを使用して貢献者やチームのページにアクセスしないでください。代わりに、完全な貢献者のリスト（ファイルとして提供しています）を使用してください。robots.txtのルールを守らないIPアドレスからのアクセスは禁止します。"


### PR DESCRIPTION
This PR adds Japanese versions of

- covid-19.po (Source-Version: 1.1)
- faq.po (Source-Version: 1.0)
- statistics.po (Source-Version: 1.0)

These changes were peer-reviewed and approved by Japanese translation team members.